### PR TITLE
Use explicit atomic bool checks

### DIFF
--- a/src/ringbuffer/concurrentqueue_adapter.h
+++ b/src/ringbuffer/concurrentqueue_adapter.h
@@ -8,7 +8,7 @@ class ConcurrentQueueAdapter : public AbstractRingBuffer {
 public:
     ConcurrentQueueAdapter(size_t capacity) : queue(capacity), max_capacity(capacity), count(0) {}
     bool produce(int item, int /*producer_id*/, const std::atomic<bool>& stop_flag) override {
-        if (stop_flag) return false;
+        if (stop_flag.load()) return false;
         // Capacity limit: concurrentqueue is non-blocking, so we count manually
         size_t expected;
         do {
@@ -20,7 +20,7 @@ public:
         return ok;
     }
     bool consume(int& item, int /*consumer_id*/, const std::atomic<bool>& stop_flag) override {
-        if (stop_flag) return false;
+        if (stop_flag.load()) return false;
         bool ok = queue.try_dequeue(item);
         if (ok) count.fetch_sub(1);
         return ok;

--- a/src/ringbuffer/lockfree_ring_buffer.cpp
+++ b/src/ringbuffer/lockfree_ring_buffer.cpp
@@ -12,7 +12,7 @@ LockFreeRingBuffer::LockFreeRingBuffer(size_t capacity)
 bool LockFreeRingBuffer::produce(int item, int /*producer_id*/, const std::atomic<bool>& stop_flag) {
     size_t pos;
     Slot* slot;
-    while (!stop_flag) {
+    while (!stop_flag.load()) {
         size_t cur_tail = tail.load(std::memory_order_relaxed);
         pos = cur_tail % capacity;
         slot = &buffer[pos];
@@ -37,7 +37,7 @@ bool LockFreeRingBuffer::produce(int item, int /*producer_id*/, const std::atomi
 bool LockFreeRingBuffer::consume(int& item, int /*consumer_id*/, const std::atomic<bool>& stop_flag) {
     size_t pos;
     Slot* slot;
-    while (!stop_flag) {
+    while (!stop_flag.load()) {
         size_t cur_head = head.load(std::memory_order_relaxed);
         pos = cur_head % capacity;
         slot = &buffer[pos];

--- a/src/ringbuffer/mutex_ring_buffer.cpp
+++ b/src/ringbuffer/mutex_ring_buffer.cpp
@@ -9,7 +9,7 @@ bool MutexRingBuffer::produce(int item, int producer_id, const std::atomic<bool>
         // Timed out while buffer was full and stop was not requested
         return false;
     }
-    if (stop_flag) {
+    if (stop_flag.load()) {
         return false;
     }
     buffer[tail] = item;
@@ -26,7 +26,7 @@ bool MutexRingBuffer::consume(int& item, int consumer_id, const std::atomic<bool
         // Timed out with no items available
         return false;
     }
-    if (count == 0 && stop_flag) {
+    if (count == 0 && stop_flag.load()) {
         return false;
     }
     if (count == 0) {


### PR DESCRIPTION
## Summary
- load atomic stop flag values explicitly
- replace implicit checks in ring buffer implementations

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "glfw3")*

------
https://chatgpt.com/codex/tasks/task_e_6858fe6cc04c8332b9e3fe6695cbab27