### PR TITLE
Fix README CMake version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 - C++20 compiler (g++/clang++, with module support)
-- CMake 3.28+ (recommended for best module support, current version after update: 4.0.3)
+- CMake 3.28+ (recommended for best module support, current version after update: 3.28.3)
 - Ninja (for building with C++20 modules via CMake)
 - GLFW
 - Dear ImGui


### PR DESCRIPTION
## Summary
- fix CMake version note in README

## Testing
- `cmake --version | head -n 1`


------
https://chatgpt.com/codex/tasks/task_e_6858fe575a988332a6ade4fa3b2e5a7e