### PR TITLE
Add unit tests for ring buffers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ find_package(OpenGL REQUIRED)
 
 # --- Threads --- 
 find_package(Threads REQUIRED)
+enable_testing()
 
 # --- Main Executable --- 
 add_executable(DonutBufferApp
@@ -72,6 +73,8 @@ target_include_directories(DonutBufferApp PUBLIC
     glad/include        # For glad.h (used by main.cpp, gui.cpp)
     imgui_backends/     # Added: For imgui_impl_glfw.h, imgui_impl_opengl3.h (used by gui.cpp, main.cpp)
 )
+
+add_subdirectory(tests)
 
 # For macOS, ensure the executable is bundled if needed
 if(APPLE)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_executable(ringbuffer_tests
+    ringbuffer_tests.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/ringbuffer/mutex_ring_buffer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/ringbuffer/lockfree_ring_buffer.cpp
+)
+
+# Include directories for ring buffer headers
+# ${PROJECT_SOURCE_DIR} is root; but we are in tests
+
+# CMake's current directory is tests; we need to include src
+
+target_include_directories(ringbuffer_tests PRIVATE
+    ${PROJECT_SOURCE_DIR}/src
+)
+
+target_link_libraries(ringbuffer_tests PRIVATE Threads::Threads)
+
+add_test(NAME RingBufferTests COMMAND ringbuffer_tests)

--- a/tests/ringbuffer_tests.cpp
+++ b/tests/ringbuffer_tests.cpp
@@ -1,0 +1,36 @@
+#include <atomic>
+#include <cassert>
+#include <iostream>
+#include "ringbuffer/mutex_ring_buffer.h"
+#include "ringbuffer/lockfree_ring_buffer.h"
+
+void test_mutex_basic() {
+    MutexRingBuffer rb(2);
+    std::atomic<bool> stop(false);
+    assert(rb.produce(1, 0, stop));
+    assert(rb.produce(2, 0, stop));
+    int v = 0;
+    assert(rb.consume(v, 0, stop));
+    assert(v == 1);
+    assert(rb.consume(v, 0, stop));
+    assert(v == 2);
+}
+
+void test_lockfree_basic() {
+    LockFreeRingBuffer rb(2);
+    std::atomic<bool> stop(false);
+    assert(rb.produce(1, 0, stop));
+    assert(rb.produce(2, 0, stop));
+    int v = 0;
+    assert(rb.consume(v, 0, stop));
+    assert(v == 1);
+    assert(rb.consume(v, 0, stop));
+    assert(v == 2);
+}
+
+int main() {
+    test_mutex_basic();
+    test_lockfree_basic();
+    std::cout << "All tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- create `tests/` directory with a basic test program
- build tests via new `tests/CMakeLists.txt`
- enable testing and add subdirectory in main `CMakeLists.txt`

## Testing
- `cmake ..` *(fails: could not find package `glfw3`)*

------
https://chatgpt.com/codex/tasks/task_e_6858fe1da6c48332915e620aed823ef1