### PR TITLE
Add local MCP server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,6 @@ build/
 # Executables
 *.exe
 *.out
+codebase/ring_buffer
+mcp/__pycache__/
 *.app

--- a/MCP_README.md
+++ b/MCP_README.md
@@ -1,0 +1,30 @@
+# Local MCP Server
+
+This FastAPI server exposes a `/command` endpoint that can interact with a local LLM via Ollama and perform tasks on a local C++ codebase.
+
+## Setup
+
+1. Install Python dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Ensure [Ollama](https://ollama.com/) is running locally and exposes the API at `http://localhost:11434` with the `llama3` model available.
+3. (Optional) Install Docker if you want commands to run inside containers.
+
+## Running
+
+```bash
+uvicorn mcp.main:app --reload
+```
+
+Send POST requests to `http://localhost:8000/command` with JSON body:
+```json
+{ "text": "your instruction" }
+```
+
+Depending on the detected intent, the server may modify `codebase/ring_buffer.cpp`, execute safe shell commands, generate scripts, or simply answer a question.
+
+The `codebase` folder includes a small driver program that links against the
+project's ring buffer implementation found under `src/ringbuffer`. Building it
+via `make -C codebase` will produce a standalone example binary using the same
+ring buffers as the main project.

--- a/codebase/Makefile
+++ b/codebase/Makefile
@@ -1,0 +1,10 @@
+all: ring_buffer
+
+mutex_ring_buffer.o: ../src/ringbuffer/mutex_ring_buffer.cpp
+	g++ -std=c++17 -I../src -c ../src/ringbuffer/mutex_ring_buffer.cpp -o mutex_ring_buffer.o
+
+ring_buffer: ring_buffer.cpp mutex_ring_buffer.o
+	g++ -std=c++17 -I../src ring_buffer.cpp mutex_ring_buffer.o -o ring_buffer
+
+clean:
+	rm -f ring_buffer mutex_ring_buffer.o

--- a/codebase/ring_buffer.cpp
+++ b/codebase/ring_buffer.cpp
@@ -1,0 +1,22 @@
+#include "../src/ringbuffer/mutex_ring_buffer.h"
+#include <atomic>
+#include <iostream>
+
+// Simple demonstration program using the existing MutexRingBuffer
+int main() {
+    MutexRingBuffer rb(4);
+    std::atomic<bool> stop{false};
+
+    // Produce a couple of items
+    rb.produce(1, 0, stop);
+    rb.produce(2, 0, stop);
+
+    // Consume and print the items
+    int value = 0;
+    rb.consume(value, 0, stop);
+    std::cout << "First item: " << value << "\n";
+    rb.consume(value, 0, stop);
+    std::cout << "Second item: " << value << "\n";
+
+    return 0;
+}

--- a/mcp/docker_utils.py
+++ b/mcp/docker_utils.py
@@ -1,0 +1,29 @@
+"""Optional utilities to run commands inside a Docker container."""
+
+import tempfile
+from pathlib import Path
+from typing import List
+
+try:
+    import docker
+except Exception:  # docker might not be installed
+    docker = None
+
+
+def run_in_container(image: str, command: List[str], volume: Path) -> str:
+    if docker is None:
+        raise RuntimeError("docker SDK not available")
+    client = docker.from_env()
+    container = client.containers.run(
+        image,
+        command,
+        volumes={str(volume): {"bind": "/workspace", "mode": "rw"}},
+        working_dir="/workspace",
+        detach=True,
+        mem_limit="512m",
+        cpu_period=100000,
+        cpu_quota=50000,
+    )
+    result = container.logs(stream=False).decode()
+    container.remove(force=True)
+    return result

--- a/mcp/llm.py
+++ b/mcp/llm.py
@@ -1,0 +1,71 @@
+import json
+from typing import Optional
+import requests
+
+OLLAMA_URL = "http://localhost:11434/api/generate"
+MODEL = "llama3"
+
+
+def call_llm(prompt: str, *, structured: bool = False) -> str:
+    """Call local Ollama LLM and return its response as a string."""
+    payload = {"model": MODEL, "prompt": prompt, "stream": False}
+    if structured:
+        payload["format"] = "json"
+    resp = requests.post(OLLAMA_URL, json=payload, timeout=60)
+    resp.raise_for_status()
+    data = resp.json()
+    # Ollama returns {"response": "..."}
+    return data.get("response", "")
+
+
+def detect_intent(text: str) -> str:
+    """Ask the LLM to classify the user command into one of the intents."""
+    prompt = (
+        "Classify the following command into one of the intents: "
+        "[modify_code, shell_command, generate_script, ask_question].\n"
+        f"Command: {text}\n"
+        'Respond with JSON: {"intent": "<intent>"}'
+    )
+    response = call_llm(prompt, structured=True)
+    try:
+        obj = json.loads(response)
+        return obj.get("intent", "ask_question")
+    except Exception:
+        return "ask_question"
+
+
+def generate_patch(user_prompt: str) -> str:
+    prompt = (
+        "You are a coding assistant. Generate a unified diff patch for the file "
+        "ring_buffer.cpp located in the current directory to satisfy the user request."
+        "Respond only with the patch.\n"
+        f"User request: {user_prompt}"
+    )
+    return call_llm(prompt)
+
+
+def generate_shell_command(user_prompt: str) -> str:
+    prompt = (
+        "Generate a safe shell command for the following request. Respond with the "
+        "command only.\nRequest: " + user_prompt
+    )
+    return call_llm(prompt)
+
+
+def generate_script(user_prompt: str) -> dict:
+    prompt = (
+        "Create a small script based on the user request. Respond with JSON:"
+        ' {"filename":..., "language":"bash|python", "run":true|false, '
+        '"content": '
+        "<script contents>"
+        "}.\nRequest: " + user_prompt
+    )
+    response = call_llm(prompt, structured=True)
+    try:
+        return json.loads(response)
+    except Exception:
+        return {}
+
+
+def answer_question(user_prompt: str) -> str:
+    return call_llm(user_prompt)

--- a/mcp/main.py
+++ b/mcp/main.py
@@ -1,0 +1,37 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from .llm import (
+    answer_question,
+    detect_intent,
+    generate_patch,
+    generate_shell_command,
+    generate_script,
+)
+from .tasks import apply_patch_and_build, run_shell_command, save_and_maybe_run_script
+
+app = FastAPI(title="Local MCP Server")
+
+
+class CommandRequest(BaseModel):
+    text: str
+
+
+@app.post("/command")
+async def command(req: CommandRequest):
+    intent = detect_intent(req.text)
+    if intent == "modify_code":
+        patch = generate_patch(req.text)
+        result = apply_patch_and_build(patch)
+        return {"intent": intent, "result": result}
+    elif intent == "shell_command":
+        cmd = generate_shell_command(req.text)
+        output = run_shell_command(cmd)
+        return {"intent": intent, "command": cmd, "output": output}
+    elif intent == "generate_script":
+        info = generate_script(req.text)
+        output = save_and_maybe_run_script(info)
+        return {"intent": intent, "info": info, "output": output}
+    else:
+        answer = answer_question(req.text)
+        return {"intent": "ask_question", "answer": answer}

--- a/mcp/tasks.py
+++ b/mcp/tasks.py
@@ -1,0 +1,61 @@
+import os
+import shlex
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import List
+
+CODEBASE_PATH = Path(__file__).resolve().parent.parent / "codebase"
+
+WHITELIST = {"ls", "cat", "echo", "make", "python3", "bash"}
+
+
+def apply_patch_and_build(patch_text: str) -> str:
+    """Apply a unified diff patch to ring_buffer.cpp and run make."""
+    patch_file = tempfile.NamedTemporaryFile("w", delete=False)
+    patch_file.write(patch_text)
+    patch_file.close()
+    result = []
+    try:
+        # Apply patch
+        proc = subprocess.run(
+            ["patch", "-p0", f"-i{patch_file.name}"],
+            cwd=CODEBASE_PATH,
+            capture_output=True,
+            text=True,
+        )
+        result.append(proc.stdout + proc.stderr)
+        # Build
+        proc = subprocess.run(
+            ["make"], cwd=CODEBASE_PATH, capture_output=True, text=True
+        )
+        result.append(proc.stdout + proc.stderr)
+    finally:
+        os.unlink(patch_file.name)
+    return "\n".join(result)
+
+
+def run_shell_command(command: str) -> str:
+    """Run a shell command if it's in the whitelist."""
+    parts = shlex.split(command)
+    if not parts or parts[0] not in WHITELIST:
+        return "Command not allowed"
+    proc = subprocess.run(parts, capture_output=True, text=True)
+    return proc.stdout + proc.stderr
+
+
+def save_and_maybe_run_script(info: dict) -> str:
+    """Save generated script to file and run if requested."""
+    filename = info.get("filename", "script.sh")
+    content = info.get("content", "")
+    run = info.get("run", False)
+    filepath = CODEBASE_PATH / filename
+    filepath.write_text(content)
+    if run:
+        if filename.endswith(".py"):
+            cmd = ["python3", str(filepath)]
+        else:
+            cmd = ["bash", str(filepath)]
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+        return proc.stdout + proc.stderr
+    return f"Script saved to {filepath}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+requests
+docker


### PR DESCRIPTION
## Summary
- create simple ring_buffer.cpp with Makefile in `codebase`
- add FastAPI-based MCP server using local LLM
- support modifying code, running shell commands, generating scripts, and answering questions
- add optional Docker helper utilities
- document usage in `MCP_README.md`
- add Python requirements file
- use project's ring buffer implementation in example program

## Testing
- `python -m py_compile mcp/*.py`
- `make -C codebase`


------
https://chatgpt.com/codex/tasks/task_e_6858fc47dabc8332b6bb31832558c7ea