### PR TITLE
Add simple CI to run tests on master pushes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,16 @@
+name: Run Tests
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build tests
+        run: g++ -std=c++20 tests/ringbuffer_tests.cpp src/ringbuffer/mutex_ring_buffer.cpp src/ringbuffer/lockfree_ring_buffer.cpp -I src -pthread -o ringbuffer_tests
+      - name: Run tests
+        run: ./ringbuffer_tests


### PR DESCRIPTION
## Summary
- add minimal GitHub Actions workflow to build and run ring buffer tests when code is pushed to `master`

## Testing
- `g++ -std=c++20 tests/ringbuffer_tests.cpp src/ringbuffer/mutex_ring_buffer.cpp src/ringbuffer/lockfree_ring_buffer.cpp -I src -pthread -o ringbuffer_tests && ./ringbuffer_tests`

------
https://chatgpt.com/codex/tasks/task_e_68593800bb208332b0738072a17a3aa6